### PR TITLE
Stick the DialogFooter to the bottom for low heights

### DIFF
--- a/client/src/components/dialog/Dialog.scss
+++ b/client/src/components/dialog/Dialog.scss
@@ -21,7 +21,7 @@
 
   .component-box {
     width: 75%;
-    height: 75%;
+    max-height: 75%;
     overflow-y: auto;
     position: relative;
     z-index: 100;


### PR DESCRIPTION
The dialog did not render correctly when there was little content (which caused the dialog footer to stay above the bottom). This PR fixes the issue