### PR TITLE
Improve the pagination component

### DIFF
--- a/client/src/components/internal/paginationItem/PaginationItem.tsx
+++ b/client/src/components/internal/paginationItem/PaginationItem.tsx
@@ -1,0 +1,50 @@
+import { cloneElement } from 'react';
+import { PaginationItemProps } from './types';
+import BaseButton from '../baseButton/BaseButton';
+
+function PaginationItem(props: PaginationItemProps): React.JSX.Element {
+  const { isSelected, page, disabled, onClick, component } = props;
+  if (component) {
+    return <CustomPageButton {...props} onClick={handleClick} />;
+  }
+
+  function handleClick(page: number) {
+    if (!disabled) {
+      onClick(page);
+    }
+  }
+
+  return (
+    <BaseButton
+      data-page={page}
+      disabled={disabled}
+      className={`component-page-item ${isSelected ? 'selected' : ''}`}
+      onClick={() => handleClick(page)}
+      aria-label={`Go to page ${page}`}
+    >
+      {page}
+    </BaseButton>
+  );
+}
+
+function CustomPageButton(props: PaginationItemProps): React.JSX.Element {
+  const { isSelected, page, disabled, onClick, component } = props;
+
+  // CustomPageButton is created only if a component is passed
+  const PureElement = cloneElement(component!);
+  const PageButton = cloneElement(PureElement, {
+    className: `${PureElement.props.className} component-page-item ${
+      isSelected ? 'selected' : ''
+    } ${disabled ? 'disabled' : ''}`,
+    'data-page': page,
+    onClick: () => onClick(page),
+    key: page,
+    'aria-label': `Go to page ${page}`,
+    disabled,
+    tabIndex: disabled ? -1 : 0,
+  });
+
+  return PageButton;
+}
+
+export default PaginationItem;

--- a/client/src/components/internal/paginationItem/PaginationItem.tsx
+++ b/client/src/components/internal/paginationItem/PaginationItem.tsx
@@ -2,6 +2,13 @@ import { cloneElement } from 'react';
 import { PaginationItemProps } from './types';
 import BaseButton from '../baseButton/BaseButton';
 
+/**
+ * A button that triggers a page change when clicked.
+ *
+ * If ``component`` is defined, this component will render that
+ * instead and attach necessary classes, click handlers, and other
+ * necessary attributes.
+ */
 function PaginationItem(props: PaginationItemProps): React.JSX.Element {
   const { isSelected, page, disabled, onClick, component } = props;
   if (component) {

--- a/client/src/components/internal/paginationItem/types.ts
+++ b/client/src/components/internal/paginationItem/types.ts
@@ -1,0 +1,7 @@
+export interface PaginationItemProps {
+  page: number;
+  disabled?: boolean;
+  isSelected: boolean;
+  component?: React.JSX.Element;
+  onClick: (value: number) => void;
+}

--- a/client/src/components/pagination/Pagination.scss
+++ b/client/src/components/pagination/Pagination.scss
@@ -44,7 +44,8 @@
       );
     }
 
-    &:disabled, &.disabled {
+    &:disabled,
+    &.disabled {
       opacity: 0.8;
       color: gray;
       cursor: not-allowed;

--- a/client/src/components/pagination/Pagination.scss
+++ b/client/src/components/pagination/Pagination.scss
@@ -23,6 +23,7 @@
     border-radius: 4px;
     @include apply-values-for-modes(color, white, black);
     @include apply-transition(background-color 0.2s, color 0.2s);
+    cursor: pointer;
 
     &:hover:not(:disabled),
     &:focus-visible {

--- a/client/src/components/pagination/Pagination.scss
+++ b/client/src/components/pagination/Pagination.scss
@@ -1,5 +1,6 @@
 @import '../../styles/colors.scss';
 @import '../../styles/util.scss';
+@import '../../styles/effects.scss';
 
 .component-pagination {
   display: flex;
@@ -24,9 +25,10 @@
     @include apply-values-for-modes(color, white, black);
     @include apply-transition(background-color 0.2s, color 0.2s);
     cursor: pointer;
+    @extend .ripple;
 
-    &:hover:not(:disabled),
-    &:focus-visible {
+    &:hover:not(:disabled, .disabled),
+    &:focus-visible:not(.disabled) {
       @include apply-values-for-modes(
         background-color,
         rgba(255, 255, 255, 0.08),
@@ -34,7 +36,7 @@
       );
     }
 
-    &.selected {
+    &.selected:not(.disabled) {
       @include apply-values-for-modes(
         background-color,
         rgba(255, 255, 255, 0.16),
@@ -42,9 +44,10 @@
       );
     }
 
-    &:disabled {
+    &:disabled, &.disabled {
       opacity: 0.8;
       color: gray;
+      cursor: not-allowed;
     }
 
     &.invisible {

--- a/client/src/components/pagination/Pagination.spec.tsx
+++ b/client/src/components/pagination/Pagination.spec.tsx
@@ -126,5 +126,22 @@ describe('Pagination component', () => {
       expect(page3.classList.contains('component-page-item')).toBe(true);
       expect(page3.classList.contains('custom-page')).toBe(true);
     });
+
+    it(`Does not change page if disabled and the 
+    rendered element is not a disableable element`, () => {
+      render(
+        <Pagination
+          disabled
+          count={9}
+          renderItem={(p) => <strong className="custom-page">{p}</strong>}
+        />,
+      );
+
+      const pages = document.querySelectorAll('strong.custom-page');
+      const page3 = pages[2] as HTMLButtonElement;
+      act(() => page3.click());
+
+      expect(page3.classList.contains('selected')).toBe(false);
+    });
   });
 });

--- a/client/src/components/pagination/Pagination.spec.tsx
+++ b/client/src/components/pagination/Pagination.spec.tsx
@@ -3,6 +3,87 @@ import Pagination from './Pagination';
 import { useState } from 'react';
 
 describe('Pagination component', () => {
+  describe('General', () => {
+    it('Page updates successfully', async () => {
+      render(<Pagination count={9} showPrev />);
+      const page1 = await screen.findByLabelText(/Go to page 1/im);
+      expect(page1.classList.contains('selected')).toBe(true);
+
+      const page2 = await screen.findByLabelText(/Go to page 2/im);
+      act(() => page2.click());
+      expect(page2.classList.contains('selected')).toBe(true);
+      expect(page1.classList.contains('selected')).toBe(false);
+
+      const page7 = await screen.findByLabelText(/Go to page 7/im);
+      act(() => page7.click());
+      expect(page7.classList.contains('selected')).toBe(true);
+      expect(page2.classList.contains('selected')).toBe(false);
+    });
+
+    it('Works as a controlled component', async () => {
+      function ControlledPagination() {
+        const [state, setState] = useState(1);
+        return <Pagination count={9} showPrev page={state} onChangePage={setState} />;
+      }
+
+      render(<ControlledPagination />);
+
+      const page2 = await screen.findByLabelText(/Go to page 2/im);
+      const page1 = await screen.findByLabelText(/Go to page 1/im);
+      act(() => page2.click());
+
+      expect(page2.classList.contains('selected')).toBe(true);
+
+      const prev = await screen.findByLabelText(/Go to previous page/im);
+      act(() => prev.click());
+      expect(page1.classList.contains('selected')).toBe(true);
+    });
+  });
+
+  describe('Next and previous buttons', () => {
+    it('Shows next button', () => {
+      render(<Pagination count={2} showNext />);
+
+      const next = document.querySelectorAll('.visible');
+      expect(next).toHaveLength(1);
+    });
+
+    it('Shows previous button', () => {
+      render(<Pagination count={2} showPrev />);
+
+      const next = document.querySelectorAll('.visible');
+      expect(next).toHaveLength(1);
+    });
+
+    it('Disables next button if at last page', () => {
+      render(<Pagination count={2} showNext page={2} />);
+      const next = document.querySelector('.visible');
+      expect(next).toBeDisabled();
+    });
+
+    it('Disables prev button if at page 1', () => {
+      render(<Pagination count={2} showPrev page={1} />);
+      const prev = document.querySelector('.visible');
+      expect(prev).toBeDisabled();
+    });
+
+    it('Previous and next buttons work', async () => {
+      render(<Pagination count={11} showPrev />);
+      const prev = await screen.findByLabelText(/Go to previous page/im);
+      const next = await screen.findByLabelText(/Go to next page/im);
+      act(() => next.click());
+      act(() => next.click());
+
+      const selected = document.querySelector('.selected');
+      expect(selected?.textContent).toBe('3');
+
+      act(() => prev.click());
+
+      const selected2 = document.querySelector('.selected');
+      expect(selected2?.textContent).toBe('2');
+    });
+  });
+
   it('Generates correct amount of pages and hides arrow buttons by default', () => {
     render(<Pagination count={2} />);
     const pages = document.querySelectorAll('button[data-page]');
@@ -12,98 +93,38 @@ describe('Pagination component', () => {
     expect(nextAndPrev).toBeNull();
   });
 
-  it('Shows next button', () => {
-    render(<Pagination count={2} showNext />);
+  describe('renderItem', () => {
+    it('Renders custom button elements', () => {
+      render(
+        <Pagination count={9} renderItem={(p) => <strong className="custom-page">{p}</strong>} />,
+      );
 
-    const next = document.querySelectorAll('.visible');
-    expect(next).toHaveLength(1);
-  });
+      const pages = document.querySelectorAll('strong.custom-page');
+      expect(pages).toHaveLength(9);
+    });
 
-  it('Shows previous button', () => {
-    render(<Pagination count={2} showPrev />);
+    it('Click functionality works', () => {
+      render(
+        <Pagination count={9} renderItem={(p) => <strong className="custom-page">{p}</strong>} />,
+      );
 
-    const next = document.querySelectorAll('.visible');
-    expect(next).toHaveLength(1);
-  });
+      const pages = document.querySelectorAll('strong.custom-page');
 
-  it('Disables next button if at last page', () => {
-    render(<Pagination count={2} showNext page={2} />);
-    const next = document.querySelector('.visible');
-    expect(next).toBeDisabled();
-  });
+      const page3 = pages[2] as HTMLButtonElement;
+      act(() => page3.click());
+      expect(page3.classList.contains('selected')).toBe(true);
+    });
 
-  it('Disables prev button if at page 1', () => {
-    render(<Pagination count={2} showPrev page={1} />);
-    const prev = document.querySelector('.visible');
-    expect(prev).toBeDisabled();
-  });
+    it('Does not override any class names provided by the parent', () => {
+      render(
+        <Pagination count={9} renderItem={(p) => <strong className="custom-page">{p}</strong>} />,
+      );
 
-  it('Previous and next buttons work', async () => {
-    render(<Pagination count={11} showPrev />);
-    const prev = await screen.findByLabelText(/Go to previous page/im);
-    const next = await screen.findByLabelText(/Go to next page/im);
-    act(() => next.click());
-    act(() => next.click());
+      const pages = document.querySelectorAll('strong.custom-page');
+      const page3 = pages[2] as HTMLButtonElement;
 
-    const selected = document.querySelector('.selected');
-    expect(selected?.textContent).toBe('3');
-
-    act(() => prev.click());
-
-    const selected2 = document.querySelector('.selected');
-    expect(selected2?.textContent).toBe('2');
-  });
-
-  it('Page updates successfully', async () => {
-    render(<Pagination count={9} showPrev />);
-    const page1 = await screen.findByLabelText(/Go to page 1/im);
-    expect(page1.classList.contains('selected')).toBe(true);
-
-    const page2 = await screen.findByLabelText(/Go to page 2/im);
-    act(() => page2.click());
-    expect(page2.classList.contains('selected')).toBe(true);
-    expect(page1.classList.contains('selected')).toBe(false);
-
-    const page7 = await screen.findByLabelText(/Go to page 7/im);
-    act(() => page7.click());
-    expect(page7.classList.contains('selected')).toBe(true);
-    expect(page2.classList.contains('selected')).toBe(false);
-  });
-
-  it('Works as a controlled component', async () => {
-    function ControlledPagination() {
-      const [state, setState] = useState(1);
-      return <Pagination count={9} showPrev page={state} onChangePage={setState} />;
-    }
-
-    render(<ControlledPagination />);
-
-    const page2 = await screen.findByLabelText(/Go to page 2/im);
-    const page1 = await screen.findByLabelText(/Go to page 1/im);
-    act(() => page2.click());
-
-    expect(page2.classList.contains('selected')).toBe(true);
-
-    const prev = await screen.findByLabelText(/Go to previous page/im);
-    act(() => prev.click());
-    expect(page1.classList.contains('selected')).toBe(true);
-  });
-
-  it('Renders pages and next/prev buttons as hyperlinks when passed a urls prop', () => {
-    const urls = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => `http://localhost:3000?page=${n}`);
-    render(<Pagination urls={urls} showPrev showNext count={9} page={2} />);
-
-    const hyperlinks = document.querySelectorAll('a');
-
-    // 9 pages + next and prev, which are also rendered as hyperlinks
-    expect(hyperlinks).toHaveLength(11);
-  });
-
-  it('Prioritizes URLs array length over count', () => {
-    const urls = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => `http://localhost:3000?page=${n}`);
-    render(<Pagination urls={urls} showPrev showNext count={3} page={2} />);
-    const hyperlinks = document.querySelectorAll('a');
-
-    expect(hyperlinks).toHaveLength(11);
+      expect(page3.classList.contains('component-page-item')).toBe(true);
+      expect(page3.classList.contains('custom-page')).toBe(true);
+    });
   });
 });

--- a/client/src/components/pagination/Pagination.tsx
+++ b/client/src/components/pagination/Pagination.tsx
@@ -1,11 +1,12 @@
 import { usePagination } from '@/hooks/usePagination/usePagination';
 import { PaginationProps } from './types';
 import './Pagination.scss';
-import { cloneElement, useEffect } from 'react';
+import { useEffect } from 'react';
 import BaseButton from '../internal/baseButton/BaseButton';
 import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from 'react-icons/md';
 import Icon from '../icon/Icon';
 import React from 'react';
+import PaginationItem from '../internal/paginationItem/PaginationItem';
 
 /**
  * A component that renders page buttons per the specified requirements.
@@ -60,33 +61,16 @@ function Pagination(props: PaginationProps): React.JSX.Element {
       </BaseButton>
       <div className="pages">
         {pagination.pages.map((p) => {
-          if (renderItem) {
-            const Page = renderItem(p.page);
-            const PureElement = cloneElement(Page);
-            const CustomPageButton = cloneElement(PureElement, {
-              className: `${PureElement.props.className} component-page-item ${
-                p.isSelected ? 'selected' : ''
-              }`,
-              'data-page': p.page,
-              onClick: () => handleChangePage(p.page),
-              key: p.page,
-              'aria-label': `Go to page ${p.page}`,
-              disabled,
-            });
-
-            return CustomPageButton;
-          }
+          const component = renderItem ? renderItem(p.page) : undefined;
           return (
-            <BaseButton
+            <PaginationItem
+              component={component}
+              page={p.page}
+              onClick={handleChangePage}
+              isSelected={p.isSelected}
               key={p.page}
-              data-page={p.page}
               disabled={disabled}
-              className={`component-page-item ${p.isSelected ? 'selected' : ''}`}
-              onClick={() => handleChangePage(p.page)}
-              aria-label={`Go to page ${p.page}`}
-            >
-              {p.page}
-            </BaseButton>
+            />
           );
         })}
       </div>

--- a/client/src/components/pagination/Pagination.tsx
+++ b/client/src/components/pagination/Pagination.tsx
@@ -11,11 +11,13 @@ import PaginationItem from '../internal/paginationItem/PaginationItem';
 /**
  * A component that renders page buttons per the specified requirements.
  * Can be turned into a controlled one by passing ``page`` and ``onChangePage``
- * props. You can also pass an array of URLs which will turn the page buttons
- * into hyperlinks.
+ * props.
  *
  * All pages are rendered as buttons by default. The ``renderItem`` prop
- * can be used to configure how the page buttons are rendered.
+ * can be used to configure how the page buttons are rendered. The custom
+ * "buttons" are implemented as closely to native buttons as possible
+ * (they have styling for a disabled button, have a tab index of -1
+ * when disabled, and do not trigger click handlers).
  */
 function Pagination(props: PaginationProps): React.JSX.Element {
   const {

--- a/client/src/components/pagination/types.ts
+++ b/client/src/components/pagination/types.ts
@@ -1,5 +1,4 @@
 import { ElementProps } from '../types/Element';
-
 export interface PaginationProps extends ElementProps {
   count?: number;
 
@@ -16,7 +15,16 @@ export interface PaginationProps extends ElementProps {
   disabled?: boolean;
 
   /**
-   * This will convert all pages to hyperlinks (using Next's ``Link`` component)
+   * Allows taking full control of how the page buttons are rendered.
+   * The returned element is used as a button, with all necessary class names
+   * combined with the general pagination class names and necessary event listeners
+   * attached to the returned component.
+   *
+   * **Note:** this option is only applied to the page numbers; the next and
+   * previous buttons are not affected and are currently not configurable.
+   * @param page for each page button in the pagination, its number
+   * will be passed as an argument to the callback.
+   * @returns
    */
-  urls?: string[];
+  renderItem?: (page?: number) => React.JSX.Element;
 }


### PR DESCRIPTION
- replace the ``urls`` prop with a ``renderItem`` prop that allows any custom element to be rendered in place of the default page button
- extract the pagination item into a separate component for modularity