### PR TITLE
Implement a utility isBrowser function

### DIFF
--- a/client/src/components/internal/baseModal/BaseModal.tsx
+++ b/client/src/components/internal/baseModal/BaseModal.tsx
@@ -4,6 +4,7 @@ import FocusTrap from 'focus-trap-react';
 import Overlay from '../overlay/Overlay';
 import { createPortal } from 'react-dom';
 import { useCallback, useEffect, useState } from 'react';
+import { isBrowser } from '@/util/isBrowser/isBrowser';
 
 /**
  * A base component for implementing modal components. Each modal:
@@ -78,7 +79,7 @@ function BaseModal(props: BaseModalProps): React.JSX.Element {
     setOverlayOpen(open || false);
   }, [open, handleEscape, handleClose]);
 
-  if (!isOpen) {
+  if (!isOpen || !isBrowser()) {
     return <></>;
   }
 

--- a/client/src/components/snackbar/Snackbar.tsx
+++ b/client/src/components/snackbar/Snackbar.tsx
@@ -7,6 +7,7 @@ import './Snackbar.scss';
 import '@/styles/colors.scss';
 import { useCallback, useEffect, useState } from 'react';
 import { useDebounce } from '@/hooks/useDebounce/useDebounce';
+import { isBrowser } from '@/util/isBrowser/isBrowser';
 
 const titles: Record<severity, string> = {
   success: 'Success!',
@@ -110,7 +111,7 @@ function Snackbar(props: SnackbarProps): JSX.Element {
     severity,
   ]);
 
-  if (!open || !window) {
+  if (!open || !isBrowser()) {
     return <></>;
   }
 

--- a/client/src/util/isBrowser/isBrowser.spec.ts
+++ b/client/src/util/isBrowser/isBrowser.spec.ts
@@ -1,0 +1,18 @@
+import { isBrowser } from './isBrowser';
+
+describe('isBrowser', () => {
+  it('Returns false if at least one query selector is not present', () => {
+    document.body.appendChild(document.createElement('p'));
+    expect(isBrowser('h1')).toBe(false);
+    expect(isBrowser('p', 'h1')).toBe(false);
+  });
+
+  it('Returns true if window and query selectors are available', () => {
+    document.body.appendChild(document.createElement('p'));
+    document.body.appendChild(document.createElement('h1'));
+
+    expect(isBrowser()).toBe(true);
+    expect(isBrowser('h1')).toBe(true);
+    expect(isBrowser('p', 'h1')).toBe(true);
+  });
+});

--- a/client/src/util/isBrowser/isBrowser.ts
+++ b/client/src/util/isBrowser/isBrowser.ts
@@ -1,0 +1,29 @@
+/**
+ * Determines whether this function is being called
+ * in a client environment.
+ */
+export function isBrowser(): boolean;
+/**
+ * Determines whether this function is being called
+ * in a client environment and whether the requested
+ * DOM elements are available.
+ * @param selectors selectors which need to be available
+ * to proceed.
+ */
+export function isBrowser(...selectors: string[]): boolean;
+export function isBrowser(...selectors: string[]): boolean {
+  const windowIsAvailable = typeof window !== 'undefined';
+  if (!windowIsAvailable) {
+    return false;
+  }
+
+  if (selectors && selectors.length) {
+    for (const selector of selectors) {
+      if (document.querySelector(selector) === null) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
This PR introduces the isBrowser function, which is useful when rendering components, particularly modal ones

The function comes with only two of three possible test case scenarios. The missing one (window is not available) is not tested because I could not mock the window object to ``undefined``.