### PR TITLE
Fix bugs with the checkbox

### DIFF
--- a/client/src/components/checkbox/Checkbox.scss
+++ b/client/src/components/checkbox/Checkbox.scss
@@ -3,7 +3,7 @@
 
 .component-checkbox {
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   gap: 4px;
   text-align: center;
 

--- a/client/src/components/checkbox/Checkbox.scss
+++ b/client/src/components/checkbox/Checkbox.scss
@@ -114,6 +114,7 @@
   &:not(:has(:checked)) {
     .checkbox {
       background-color: transparent;
+      color: transparent;
     }
   }
 }


### PR DESCRIPTION
Two bugs were present before this PR:
- the checkboxes took up the entire space due to their ``display`` property. They are now ``inline-flex`` and only take up as much space as needed.
- the icon was visible for some color variants even when not checked due to one of the SCSS color files, now the icon is transparent when not checked