### PR TITLE
Fix issues with the text fields

### DIFF
--- a/client/.storybook/preview.ts
+++ b/client/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import type { Preview } from '@storybook/react';
-
+import '../src/app/globals.scss'
 const preview: Preview = {
   parameters: {
     controls: {

--- a/client/src/components/textField/TextField.scss
+++ b/client/src/components/textField/TextField.scss
@@ -6,6 +6,7 @@
   border-radius: 5px;
   border: 1px solid gray;
   outline: 1px solid gray;
+  width: 100%;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: outline-color 0.25s ease-in-out;
@@ -24,19 +25,16 @@
   &.small {
     padding: 8px 4px;
     font-size: 10pt;
-    width: 200px;
   }
 
   &.medium {
     padding: 16px 8px;
     font-size: 12pt;
-    width: 250px;
   }
 
   &.large {
     padding: 24px 12px;
     font-size: 14pt;
-    width: 300px;
   }
 }
 
@@ -50,37 +48,37 @@ textarea.component-text-field {
 }
 
 .component-helper-text-wrapper {
-  position: relative;
-  bottom: 20px;
-  top: 20px;
+  display: block;
 
+  &.small {
+    width: 200px;
+  }
+
+  &.medium {
+    width: 250px;
+  }
+
+  &.large {
+    width: 300px;
+  }
   .component-helper-text {
-    position: absolute;
     font-size: 10pt;
-    top: 150%;
-    left: 0;
-    right: 0;
+    margin-top: 3px;
     @extend .theme-text;
   }
 
   .component-label-text {
-    position: absolute;
-    left: 0;
-    right: 0;
-
+    margin-bottom: 3px;
     &.large {
       font-size: 11pt;
-      bottom: 75px;
     }
 
     &.medium {
       font-size: 9pt;
-      bottom: 55px;
     }
 
     &.small {
       font-size: 8pt;
-      bottom: 36px;
     }
   }
 

--- a/client/src/components/textField/TextField.scss
+++ b/client/src/components/textField/TextField.scss
@@ -60,12 +60,14 @@ textarea.component-text-field {
     top: 150%;
     left: 0;
     right: 0;
+    @extend .theme-text;
   }
 
   .component-label-text {
     position: absolute;
     left: 0;
     right: 0;
+
     &.large {
       font-size: 11pt;
       bottom: 75px;

--- a/client/src/components/textField/client/TextField.spec.tsx
+++ b/client/src/components/textField/client/TextField.spec.tsx
@@ -3,9 +3,14 @@ import TextField from './TextField';
 
 describe('TextField (client)', () => {
   describe('Placeholder', () => {
-    it('Displays correct placeholder when passed one', async () => {
-      render(<TextField value="a" onChange={() => {}} placeholder="Test" />);
+    it('Displays correct placeholder when passed one and the field is required', async () => {
+      render(<TextField value="a" required onChange={() => {}} placeholder="Test" />);
       await screen.findByPlaceholderText('Test*');
+    });
+
+    it('Displays correct placeholder when passed one and the field is not required', async () => {
+      render(<TextField value="a" onChange={() => {}} placeholder="Test" />);
+      await screen.findByPlaceholderText('Test');
     });
   });
 });

--- a/client/src/components/textField/client/TextField.tsx
+++ b/client/src/components/textField/client/TextField.tsx
@@ -4,6 +4,8 @@ import '../TextField.scss';
 import '@/styles/colors.scss';
 import { useCallback, useEffect, useRef } from 'react';
 import { HelperTextProps, LabelTextProps } from '../../types/BaseInput';
+import { _generatePlaceholderText } from '../generatePlaceholderText';
+
 /**
  * A controlled ``input`` field.
  */
@@ -27,6 +29,7 @@ function TextField(props: TextFieldProps): React.JSX.Element {
     ...others
   } = props;
   const ref = useRef<HTMLTextAreaElement>(null);
+  const placeholderText = _generatePlaceholderText(placeholder, required);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     if (onChange) {
@@ -59,7 +62,7 @@ function TextField(props: TextFieldProps): React.JSX.Element {
         theme-emphasis-text ${size} ${className}`}
           rows={1}
           ref={ref}
-          placeholder={placeholder ? placeholder + '*' : undefined}
+          placeholder={placeholderText}
           value={value}
           form={form}
           disabled={disabled}
@@ -80,7 +83,7 @@ function TextField(props: TextFieldProps): React.JSX.Element {
         onChange={handleChange}
         className={`component-text-field
         accent-background theme-emphasis-text ${size}`}
-        placeholder={placeholder ? placeholder + '*' : undefined}
+        placeholder={placeholderText}
         value={value}
         form={form}
         disabled={disabled}

--- a/client/src/components/textField/client/TextField.tsx
+++ b/client/src/components/textField/client/TextField.tsx
@@ -2,7 +2,7 @@
 import { TextFieldProps } from '../types';
 import '../TextField.scss';
 import '@/styles/colors.scss';
-import { useEffect, useRef } from 'react';
+import { useCallback, useLayoutEffect, useRef } from 'react';
 import { HelperTextProps, LabelTextProps } from '../../types/BaseInput';
 /**
  * A controlled ``input`` field.
@@ -27,6 +27,7 @@ function TextField(props: TextFieldProps): React.JSX.Element {
     ...others
   } = props;
   const ref = useRef<HTMLTextAreaElement>(null);
+
   function handleChange(event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     if (onChange) {
       onChange(event);
@@ -35,23 +36,22 @@ function TextField(props: TextFieldProps): React.JSX.Element {
     adjustHeight();
   }
 
-  function adjustHeight() {
+  const adjustHeight = useCallback(() => {
     if (ref.current && autoresize) {
       ref.current.style.height = 'auto';
       ref.current.style.height = `${ref.current!.scrollHeight}px`;
     }
-  }
+  }, [autoresize]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     adjustHeight();
-  });
+  }, [adjustHeight]);
 
   if (type === 'text' && autoresize) {
     const height = Number(ref.current?.scrollHeight) || 0;
     return (
-      <label className={`component-helper-text-wrapper ${className}`} {...others}>
+      <label className={`component-helper-text-wrapper ${size} ${className}`} {...others}>
         <LabelText bottom={height} size={size} labelText={label} />
-        <HelperText helperText={helperText} />
         <textarea
           onChange={handleChange}
           className={`component-text-field accent-background
@@ -66,14 +66,14 @@ function TextField(props: TextFieldProps): React.JSX.Element {
           readOnly={readonly}
           required={required}
         ></textarea>
+        <HelperText helperText={helperText} />
       </label>
     );
   }
 
   return (
-    <label className={`component-helper-text-wrapper ${className}`} {...others}>
+    <label className={`component-helper-text-wrapper ${size} ${className}`} {...others}>
       <LabelText disabled={disabled} size={size} labelText={label} />
-      <HelperText disabled={disabled} helperText={helperText} />
       <input
         type={type}
         onChange={handleChange}
@@ -88,6 +88,7 @@ function TextField(props: TextFieldProps): React.JSX.Element {
         required={required}
         list={list}
       />
+      <HelperText disabled={disabled} helperText={helperText} />
     </label>
   );
 }
@@ -107,13 +108,9 @@ function LabelText(props: LabelTextProps): React.JSX.Element {
     return <></>;
   }
 
-  const style = props.bottom ? { bottom: props.bottom + 5 } : undefined;
   const disabledClass = props.disabled ? 'disabled' : '';
   return (
-    <div
-      style={style}
-      className={`component-label-text theme-emphasis-text ${props.size} ${disabledClass}`}
-    >
+    <div className={`component-label-text theme-emphasis-text ${props.size} ${disabledClass}`}>
       {props.labelText}
     </div>
   );

--- a/client/src/components/textField/client/TextField.tsx
+++ b/client/src/components/textField/client/TextField.tsx
@@ -2,7 +2,7 @@
 import { TextFieldProps } from '../types';
 import '../TextField.scss';
 import '@/styles/colors.scss';
-import { useCallback, useLayoutEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { HelperTextProps, LabelTextProps } from '../../types/BaseInput';
 /**
  * A controlled ``input`` field.
@@ -43,9 +43,11 @@ function TextField(props: TextFieldProps): React.JSX.Element {
     }
   }, [autoresize]);
 
-  useLayoutEffect(() => {
-    adjustHeight();
-  }, [adjustHeight]);
+  useEffect(() => {
+    if (autoresize) {
+      adjustHeight();
+    }
+  }, [adjustHeight, autoresize]);
 
   if (type === 'text' && autoresize) {
     const height = Number(ref.current?.scrollHeight) || 0;

--- a/client/src/components/textField/client/TextField.tsx
+++ b/client/src/components/textField/client/TextField.tsx
@@ -50,10 +50,9 @@ function TextField(props: TextFieldProps): React.JSX.Element {
   }, [adjustHeight, autoresize]);
 
   if (type === 'text' && autoresize) {
-    const height = Number(ref.current?.scrollHeight) || 0;
     return (
       <label className={`component-helper-text-wrapper ${size} ${className}`} {...others}>
-        <LabelText bottom={height} size={size} labelText={label} />
+        <LabelText size={size} labelText={label} />
         <textarea
           onChange={handleChange}
           className={`component-text-field accent-background

--- a/client/src/components/textField/generatePlaceholderText.ts
+++ b/client/src/components/textField/generatePlaceholderText.ts
@@ -1,0 +1,11 @@
+export function _generatePlaceholderText(
+  placeholder: string | undefined,
+  required: boolean | undefined,
+): string {
+  placeholder = placeholder || '';
+  if (required) {
+    return placeholder + '*';
+  }
+
+  return placeholder;
+}

--- a/client/src/components/textField/server/TextField.spec.tsx
+++ b/client/src/components/textField/server/TextField.spec.tsx
@@ -3,9 +3,14 @@ import TextField from './TextField';
 
 describe('TextField (server)', () => {
   describe('Placeholder', () => {
-    it('Displays correct placeholder when passed one', async () => {
-      render(<TextField placeholder="Test" />);
+    it('Displays correct placeholder when passed one and the field is required', async () => {
+      render(<TextField placeholder="Test" required />);
       await screen.findByPlaceholderText('Test*');
+    });
+
+    it('Displays correct placeholder when passed one and the field is not required', async () => {
+      render(<TextField placeholder="Test" />);
+      await screen.findByPlaceholderText('Test');
     });
   });
 });

--- a/client/src/components/textField/server/TextField.tsx
+++ b/client/src/components/textField/server/TextField.tsx
@@ -73,13 +73,9 @@ function LabelText(props: LabelTextProps): React.JSX.Element {
     return <></>;
   }
 
-  const style = props.bottom ? { bottom: props.bottom + 5 } : undefined;
   const disabledClass = props.disabled ? 'disabled' : '';
   return (
-    <div
-      style={style}
-      className={`component-label-text theme-emphasis-text ${props.size} ${disabledClass}`}
-    >
+    <div className={`component-label-text theme-emphasis-text ${props.size} ${disabledClass}`}>
       {props.labelText}
     </div>
   );

--- a/client/src/components/textField/server/TextField.tsx
+++ b/client/src/components/textField/server/TextField.tsx
@@ -2,6 +2,7 @@ import '../TextField.scss';
 import '@/styles/colors.scss';
 import { HelperTextProps, LabelTextProps } from '../../types/BaseInput';
 import { ServerTextFieldProps } from './types';
+import { _generatePlaceholderText } from '../generatePlaceholderText';
 /**
  * An uncontrolled text field, suitable for server components. Note that
  * this text field does not support automatic resizing; use the client
@@ -30,6 +31,7 @@ function TextField(props: ServerTextFieldProps): React.JSX.Element {
     step,
     ...others
   } = props;
+  const placeholderText = _generatePlaceholderText(placeholder, required);
 
   return (
     <label className={`component-helper-text-wrapper ${className}`} {...others}>
@@ -38,7 +40,7 @@ function TextField(props: ServerTextFieldProps): React.JSX.Element {
         type={type}
         className={`component-text-field
         accent-background theme-emphasis-text ${size}`}
-        placeholder={placeholder ? placeholder + '*' : undefined}
+        placeholder={placeholderText}
         form={form}
         disabled={disabled}
         name={name}

--- a/client/src/components/textField/server/TextField.tsx
+++ b/client/src/components/textField/server/TextField.tsx
@@ -34,7 +34,6 @@ function TextField(props: ServerTextFieldProps): React.JSX.Element {
   return (
     <label className={`component-helper-text-wrapper ${className}`} {...others}>
       <LabelText disabled={disabled} size={size} labelText={label} />
-      <HelperText disabled={disabled} helperText={helperText} />
       <input
         type={type}
         className={`component-text-field
@@ -54,6 +53,7 @@ function TextField(props: ServerTextFieldProps): React.JSX.Element {
         step={step}
         defaultValue={value}
       />
+      <HelperText disabled={disabled} helperText={helperText} />
     </label>
   );
 }

--- a/client/src/components/types/BaseInput.ts
+++ b/client/src/components/types/BaseInput.ts
@@ -19,6 +19,5 @@ export interface HelperTextProps {
 export interface LabelTextProps {
   labelText: string;
   size: size;
-  bottom?: number;
   disabled?: boolean;
 }


### PR DESCRIPTION
- helper text now matches the theme
- before this PR, the label would initially be stuck inside the autoresizing textarea before correcting itself with a single input. This PR makes the label and helper text non-absolute, fixing this issue, though keep in mind that those now contribute to the element's height.
- global styles are now available in the Storybook components
- asterisks now appear on inputs only when ``required`` is passed