### PR TITLE
Fix issues with the Snackbar component

### DIFF
--- a/client/src/features/snackbar/Snackbar.scss
+++ b/client/src/features/snackbar/Snackbar.scss
@@ -16,7 +16,6 @@
 
   .component-alert {
     @include zoom-in();
-    padding-bottom: 8px;
   }
 
   .snackbar-close-button {


### PR DESCRIPTION
- remove extra padding caused by a prior update in the Alert component
- the timer didn't reset correctly when the snackbar is updated, this should now be fixed