### PR TITLE
Add new variants for buttons

### DIFF
--- a/client/src/components/button/Button.scss
+++ b/client/src/components/button/Button.scss
@@ -21,6 +21,8 @@
   }
 
   &.background {
+    background-color: gray;
+
     &:disabled,
     &.disabled {
       @include apply-values-for-modes(

--- a/client/src/components/button/Button.scss
+++ b/client/src/components/button/Button.scss
@@ -10,35 +10,39 @@
   display: inline-flex;
   text-align: center;
 
+  /* in case a color is not provided */
+  background-color: transparent;
+  @include apply-theme-text();
+  @include apply-accent-hover();
+  @include apply-accent-click();
+
+  &.outlined {
+    border: 1px solid gray;
+  }
+
+  &.background {
+    &:disabled,
+    &.disabled {
+      @include apply-values-for-modes(
+        background-color,
+        rgba(255, 255, 255, 0.12),
+        rgba(0, 0, 0, 0.12)
+      );
+    }
+  }
+  /* end of no color */
+
   border: 1px solid transparent;
-
   @include apply-palette-backgrounds();
-
-  // &.background-transparent {
-  //   background-color: transparent;
-  //   @include apply-values-for-modes(color, $text-medium-dark, $text-medium-light);
-  //   @include apply-transition(background-color 0.3s);
-
-  //   &:not(:disabled),
-  //   &:not(.disabled) {
-  //     &:hover {
-  //       background-color: rgba(128, 128, 128, 0.2);
-  //     }
-
-  //     &:active {
-  //       background-color: rgba(128, 128, 128, 0.4);
-  //     }
-  //   }
-  // }
-
   @include apply-palette-text($interactive: true);
   @include apply-palette-outlined-text($interactive: true);
 
-  &[class*="text-"], &[class*="outlined-"] {
+  &[class*='text-'],
+  &[class*='outlined-'] {
     background-color: transparent;
   }
 
-  &[class*="background-"] {
+  &[class*='background-'] {
     @include apply-palette-effects();
   }
 

--- a/client/src/components/button/Button.scss
+++ b/client/src/components/button/Button.scss
@@ -23,6 +23,14 @@
   &.background {
     background-color: gray;
 
+    &:hover {
+      background-color: rgba(128, 128, 128, 0.6);
+    }
+
+    &:active {
+      background-color: rgba(128, 128, 128, 0.3);
+    }
+
     &:disabled,
     &.disabled {
       @include apply-values-for-modes(

--- a/client/src/components/button/Button.scss
+++ b/client/src/components/button/Button.scss
@@ -9,6 +9,8 @@
   display: inline-flex;
   text-align: center;
 
+  border: 1px solid transparent;
+
   @include apply-palette-backgrounds();
   @include apply-palette-effects();
 
@@ -30,6 +32,7 @@
   // }
 
   @include apply-palette-text();
+  @include apply-palette-outlined-text();
 
   &[class*="text-"], &[class*="outlined-"] {
     background-color: transparent;

--- a/client/src/components/button/Button.scss
+++ b/client/src/components/button/Button.scss
@@ -12,21 +12,27 @@
   @include apply-palette-backgrounds();
   @include apply-palette-effects();
 
-  &.background-transparent {
+  // &.background-transparent {
+  //   background-color: transparent;
+  //   @include apply-values-for-modes(color, $text-medium-dark, $text-medium-light);
+  //   @include apply-transition(background-color 0.3s);
+
+  //   &:not(:disabled),
+  //   &:not(.disabled) {
+  //     &:hover {
+  //       background-color: rgba(128, 128, 128, 0.2);
+  //     }
+
+  //     &:active {
+  //       background-color: rgba(128, 128, 128, 0.4);
+  //     }
+  //   }
+  // }
+
+  @include apply-palette-text();
+
+  &[class*="text-"], &[class*="outlined-"] {
     background-color: transparent;
-    @include apply-values-for-modes(color, $text-medium-dark, $text-medium-light);
-    @include apply-transition(background-color 0.3s);
-
-    &:not(:disabled),
-    &:not(.disabled) {
-      &:hover {
-        background-color: rgba(128, 128, 128, 0.2);
-      }
-
-      &:active {
-        background-color: rgba(128, 128, 128, 0.4);
-      }
-    }
   }
 
   @include apply-font-sizes();

--- a/client/src/components/button/Button.scss
+++ b/client/src/components/button/Button.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @import '../../styles/util.scss';
 @import '../../styles/colors.scss';
 @import '../../styles/font.scss';
@@ -12,7 +13,6 @@
   border: 1px solid transparent;
 
   @include apply-palette-backgrounds();
-  @include apply-palette-effects();
 
   // &.background-transparent {
   //   background-color: transparent;
@@ -31,11 +31,15 @@
   //   }
   // }
 
-  @include apply-palette-text();
-  @include apply-palette-outlined-text();
+  @include apply-palette-text($interactive: true);
+  @include apply-palette-outlined-text($interactive: true);
 
   &[class*="text-"], &[class*="outlined-"] {
     background-color: transparent;
+  }
+
+  &[class*="background-"] {
+    @include apply-palette-effects();
   }
 
   @include apply-font-sizes();

--- a/client/src/components/button/Button.stories.tsx
+++ b/client/src/components/button/Button.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
 export const Sizes: Story = {
   render: () => (
     <>
-      <p>Variants: primary, secondary, info, error, transparent, disabled</p>
+      <p>Variants: primary, secondary, info, error, no color, disabled</p>
       <div>
         <h6>Small</h6>
         <Button size="small" color="primary">
@@ -44,9 +44,7 @@ export const Sizes: Story = {
         <Button size="small" color="error">
           Hello
         </Button>
-        <Button size="small" color="transparent">
-          Hello
-        </Button>
+        <Button size="small">Hello</Button>
         <Button size="small" disabled>
           Hello
         </Button>
@@ -65,9 +63,7 @@ export const Sizes: Story = {
         <Button size="medium" color="error">
           Hello
         </Button>
-        <Button size="medium" color="transparent">
-          Hello
-        </Button>
+        <Button size="medium">Hello</Button>
         <Button size="medium" disabled>
           Hello
         </Button>
@@ -86,9 +82,7 @@ export const Sizes: Story = {
         <Button size="large" color="error">
           Hello
         </Button>
-        <Button size="large" color="transparent">
-          Hello
-        </Button>
+        <Button size="large">Hello</Button>
         <Button onClick={fn} size="large" disabled>
           Hello
         </Button>
@@ -114,9 +108,7 @@ export const Variants: Story = {
         <Button variant="text" color="error">
           Hello
         </Button>
-        <Button variant="text" color="transparent">
-          Hello
-        </Button>
+        <Button variant="text">Hello</Button>
         <Button variant="text" disabled>
           Hello
         </Button>
@@ -135,9 +127,7 @@ export const Variants: Story = {
         <Button variant="fill" color="error">
           Hello
         </Button>
-        <Button variant="fill" color="transparent">
-          Hello
-        </Button>
+        <Button variant="fill">Hello</Button>
         <Button variant="fill" disabled>
           Hello
         </Button>
@@ -156,9 +146,7 @@ export const Variants: Story = {
         <Button variant="outlined" color="error">
           Hello
         </Button>
-        <Button variant="outlined" color="transparent">
-          Hello
-        </Button>
+        <Button variant="outlined">Hello</Button>
         <Button variant="outlined" disabled>
           Hello
         </Button>

--- a/client/src/components/button/Button.stories.tsx
+++ b/client/src/components/button/Button.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
 export const Sizes: Story = {
   render: () => (
     <>
-      <p>Variants: primary, secondary, info, error, no color, disabled</p>
+      <p>Variants: primary, secondary, info, error, success, warning, no color, disabled</p>
       <div>
         <h6>Small</h6>
         <Button size="small" color="primary">
@@ -42,6 +42,12 @@ export const Sizes: Story = {
           Hello
         </Button>
         <Button size="small" color="error">
+          Hello
+        </Button>
+        <Button size="small" color="success">
+          Hello
+        </Button>
+        <Button size="small" color="warning">
           Hello
         </Button>
         <Button size="small">Hello</Button>
@@ -63,6 +69,12 @@ export const Sizes: Story = {
         <Button size="medium" color="error">
           Hello
         </Button>
+        <Button size="medium" color="success">
+          Hello
+        </Button>
+        <Button size="medium" color="warning">
+          Hello
+        </Button>
         <Button size="medium">Hello</Button>
         <Button size="medium" disabled>
           Hello
@@ -80,6 +92,12 @@ export const Sizes: Story = {
           Hello
         </Button>
         <Button size="large" color="error">
+          Hello
+        </Button>
+        <Button size="large" color="success">
+          Hello
+        </Button>
+        <Button size="large" color="warning">
           Hello
         </Button>
         <Button size="large">Hello</Button>
@@ -102,6 +120,12 @@ export const Variants: Story = {
         <Button variant="text" color="secondary">
           Hello
         </Button>
+        <Button variant="text" color="success">
+          Hello
+        </Button>
+        <Button variant="text" color="warning">
+          Hello
+        </Button>
         <Button variant="text" color="info">
           Hello
         </Button>
@@ -121,6 +145,12 @@ export const Variants: Story = {
         <Button variant="fill" color="secondary">
           Hello
         </Button>
+        <Button variant="fill" color="success">
+          Hello
+        </Button>
+        <Button variant="fill" color="warning">
+          Hello
+        </Button>
         <Button variant="fill" color="info">
           Hello
         </Button>
@@ -138,6 +168,12 @@ export const Variants: Story = {
           Hello
         </Button>
         <Button variant="outlined" color="secondary">
+          Hello
+        </Button>
+        <Button variant="outlined" color="success">
+          Hello
+        </Button>
+        <Button variant="outlined" color="warning">
           Hello
         </Button>
         <Button variant="outlined" color="info">
@@ -180,11 +216,13 @@ export const WithIcon: Story = {
   render: () => (
     <>
       <div style={{ marginBottom: '2em' }}>
-        <Button icon={<MdCancel />} size="small">
+        <Button color="primary" icon={<MdCancel />} size="small">
           Small
         </Button>
-        <Button icon={<MdCancel />}>Medium</Button>
-        <Button icon={<MdCancel />} size="large">
+        <Button color="success" icon={<MdCancel />}>
+          Medium
+        </Button>
+        <Button color="error" icon={<MdCancel />} size="large">
           Large
         </Button>
       </div>

--- a/client/src/components/button/Button.stories.tsx
+++ b/client/src/components/button/Button.stories.tsx
@@ -97,6 +97,76 @@ export const Sizes: Story = {
   ),
 };
 
+export const Variants: Story = {
+  render: () => (
+    <>
+      <div>
+        <h6>Text</h6>
+        <Button variant="text" color="primary">
+          Hello
+        </Button>
+        <Button variant="text" color="secondary">
+          Hello
+        </Button>
+        <Button variant="text" color="info">
+          Hello
+        </Button>
+        <Button variant="text" color="error">
+          Hello
+        </Button>
+        <Button variant="text" color="transparent">
+          Hello
+        </Button>
+        <Button variant="text" disabled>
+          Hello
+        </Button>
+      </div>
+      <div>
+        <h6>Fill (default)</h6>
+        <Button variant="fill" color="primary">
+          Hello
+        </Button>
+        <Button variant="fill" color="secondary">
+          Hello
+        </Button>
+        <Button variant="fill" color="info">
+          Hello
+        </Button>
+        <Button variant="fill" color="error">
+          Hello
+        </Button>
+        <Button variant="fill" color="transparent">
+          Hello
+        </Button>
+        <Button variant="fill" disabled>
+          Hello
+        </Button>
+      </div>
+      <div>
+        <h6>Outlined</h6>
+        <Button variant="outlined" color="primary">
+          Hello
+        </Button>
+        <Button variant="outlined" color="secondary">
+          Hello
+        </Button>
+        <Button variant="outlined" color="info">
+          Hello
+        </Button>
+        <Button variant="outlined" color="error">
+          Hello
+        </Button>
+        <Button variant="outlined" color="transparent">
+          Hello
+        </Button>
+        <Button variant="outlined" disabled>
+          Hello
+        </Button>
+      </div>
+    </>
+  ),
+};
+
 export const LinkButton: Story = {
   render: () => (
     <>

--- a/client/src/components/button/Button.stories.tsx
+++ b/client/src/components/button/Button.stories.tsx
@@ -101,7 +101,7 @@ export const Variants: Story = {
   render: () => (
     <>
       <div>
-        <h6>Text</h6>
+        <h3>Text</h3>
         <Button variant="text" color="primary">
           Hello
         </Button>
@@ -122,7 +122,7 @@ export const Variants: Story = {
         </Button>
       </div>
       <div>
-        <h6>Fill (default)</h6>
+        <h3>Fill (default)</h3>
         <Button variant="fill" color="primary">
           Hello
         </Button>
@@ -143,7 +143,7 @@ export const Variants: Story = {
         </Button>
       </div>
       <div>
-        <h6>Outlined</h6>
+        <h3>Outlined</h3>
         <Button variant="outlined" color="primary">
           Hello
         </Button>

--- a/client/src/components/button/Button.tsx
+++ b/client/src/components/button/Button.tsx
@@ -13,7 +13,7 @@ import { generateVariantClassName } from '@/util/generateVariantClassName/genera
 function Button(props: ButtonProps): React.JSX.Element {
   const {
     className = '',
-    color = 'primary',
+    color,
     size = 'medium',
     children,
     onClick,
@@ -23,12 +23,13 @@ function Button(props: ButtonProps): React.JSX.Element {
   } = props;
 
   const variantClassName = generateVariantClassName(variant);
+  const variantColorClassName = color ? `${variantClassName}-${color}` : variantClassName;
 
   return (
     <BaseButtonWithIcon
       icon={icon}
       className={`component-button 
-        ${variantClassName}-${color} ${color}-effects size-${size}
+        ${variantColorClassName} ${color}-effects size-${size}
         ${icon ? 'with-icon' : ''} ${className}`}
       onClick={onClick}
       {...others}

--- a/client/src/components/button/Button.tsx
+++ b/client/src/components/button/Button.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ButtonProps } from './types';
 import './Button.scss';
 import BaseButtonWithIcon from '../internal/baseButton/BaseButtonWithIcon';
+import { generateVariantClassName } from '@/util/generateVariantClassName/generateVariantClassName';
 
 /**
  * A standard client button with preconfigured styling and coloring.
@@ -17,13 +18,18 @@ function Button(props: ButtonProps): React.JSX.Element {
     children,
     onClick,
     icon,
+    variant = 'fill',
     ...others
   } = props;
+
+  const variantClassName = generateVariantClassName(variant);
+
   return (
     <BaseButtonWithIcon
       icon={icon}
       className={`component-button 
-        background-${color} ${color}-effects size-${size} ${icon ? 'with-icon' : ''} ${className}`}
+        ${variantClassName}-${color} ${color}-effects size-${size}
+        ${icon ? 'with-icon' : ''} ${className}`}
       onClick={onClick}
       {...others}
     >

--- a/client/src/components/button/iconButton/IconButton.scss
+++ b/client/src/components/button/iconButton/IconButton.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/colors.scss';
+
 .component-icon-button {
   border-radius: 50%;
   display: inline-block;

--- a/client/src/components/button/iconButton/IconButton.scss
+++ b/client/src/components/button/iconButton/IconButton.scss
@@ -2,7 +2,7 @@
 
 .component-icon-button {
   border-radius: 50%;
-  display: inline-block;
+  display: inline-flex;
 
   .component-icon {
     &.size-large {

--- a/client/src/components/button/iconButton/IconButton.stories.tsx
+++ b/client/src/components/button/iconButton/IconButton.stories.tsx
@@ -99,6 +99,76 @@ export const Sizes: Story = {
   ),
 };
 
+export const Variants: Story = {
+  render: () => (
+    <>
+      <div>
+        <h6>Text</h6>
+        <IconButton variant="text" color="primary">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="text" color="secondary">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="text" color="info">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="text" color="error">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="text" color="transparent">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="text" disabled>
+          <MdCancel />
+        </IconButton>
+      </div>
+      <div>
+        <h6>Fill (default)</h6>
+        <IconButton variant="fill" color="primary">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="fill" color="secondary">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="fill" color="info">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="fill" color="error">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="fill" color="transparent">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="fill" disabled>
+          <MdCancel />
+        </IconButton>
+      </div>
+      <div>
+        <h6>Outlined</h6>
+        <IconButton variant="outlined" color="primary">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="outlined" color="secondary">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="outlined" color="info">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="outlined" color="error">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="outlined" color="transparent">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="outlined" disabled>
+          <MdCancel />
+        </IconButton>
+      </div>
+    </>
+  ),
+};
+
 export const LinkIconButton: Story = {
   render: () => (
     <>

--- a/client/src/components/button/iconButton/IconButton.stories.tsx
+++ b/client/src/components/button/iconButton/IconButton.stories.tsx
@@ -30,7 +30,7 @@ export const Sizes: Story = {
   render: () => (
     <>
       <>
-        <p>Variants: primary, secondary, info, error, no color, disabled</p>
+        <p>Variants: primary, secondary, info, error, success, warning, no color, disabled</p>
         <div>
           <h6>Small</h6>
           <IconButton onClick={fn} size="small" color="primary">
@@ -43,6 +43,12 @@ export const Sizes: Story = {
             <MdCancel />
           </IconButton>
           <IconButton onClick={fn} size="small" color="error">
+            <MdCancel />
+          </IconButton>
+          <IconButton onClick={fn} size="small" color="success">
+            <MdCancel />
+          </IconButton>
+          <IconButton onClick={fn} size="small" color="warning">
             <MdCancel />
           </IconButton>
           <IconButton onClick={fn} size="small">
@@ -66,6 +72,12 @@ export const Sizes: Story = {
           <IconButton onClick={fn} size="medium" color="error">
             <MdCancel />
           </IconButton>
+          <IconButton onClick={fn} size="medium" color="success">
+            <MdCancel />
+          </IconButton>
+          <IconButton onClick={fn} size="medium" color="warning">
+            <MdCancel />
+          </IconButton>
           <IconButton onClick={fn} size="medium">
             <MdCancel />
           </IconButton>
@@ -85,6 +97,12 @@ export const Sizes: Story = {
             <MdCancel />
           </IconButton>
           <IconButton size="large" color="error">
+            <MdCancel />
+          </IconButton>
+          <IconButton onClick={fn} size="large" color="success">
+            <MdCancel />
+          </IconButton>
+          <IconButton onClick={fn} size="large" color="warning">
             <MdCancel />
           </IconButton>
           <IconButton size="large">
@@ -110,6 +128,12 @@ export const Variants: Story = {
         <IconButton variant="text" color="secondary">
           <MdCancel />
         </IconButton>
+        <IconButton variant="text" color="success">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="text" color="warning">
+          <MdCancel />
+        </IconButton>
         <IconButton variant="text" color="info">
           <MdCancel />
         </IconButton>
@@ -129,6 +153,12 @@ export const Variants: Story = {
           <MdCancel />
         </IconButton>
         <IconButton variant="fill" color="secondary">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="fill" color="success">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="fill" color="warning">
           <MdCancel />
         </IconButton>
         <IconButton variant="fill" color="info">
@@ -152,6 +182,12 @@ export const Variants: Story = {
         <IconButton variant="outlined" color="secondary">
           <MdCancel />
         </IconButton>
+        <IconButton variant="outlined" color="success">
+          <MdCancel />
+        </IconButton>
+        <IconButton variant="outlined" color="warning">
+          <MdCancel />
+        </IconButton>
         <IconButton variant="outlined" color="info">
           <MdCancel />
         </IconButton>
@@ -173,7 +209,6 @@ export const LinkIconButton: Story = {
   render: () => (
     <>
       <div>
-        <p>Hover over each button for its classification</p>
         <IconButton
           title="External link (no target)"
           href="https://storybook.js.org/"

--- a/client/src/components/button/iconButton/IconButton.stories.tsx
+++ b/client/src/components/button/iconButton/IconButton.stories.tsx
@@ -103,7 +103,7 @@ export const Variants: Story = {
   render: () => (
     <>
       <div>
-        <h6>Text</h6>
+        <h3>Text</h3>
         <IconButton variant="text" color="primary">
           <MdCancel />
         </IconButton>
@@ -124,7 +124,7 @@ export const Variants: Story = {
         </IconButton>
       </div>
       <div>
-        <h6>Fill (default)</h6>
+        <h3>Fill (default)</h3>
         <IconButton variant="fill" color="primary">
           <MdCancel />
         </IconButton>
@@ -145,7 +145,7 @@ export const Variants: Story = {
         </IconButton>
       </div>
       <div>
-        <h6>Outlined</h6>
+        <h3>Outlined</h3>
         <IconButton variant="outlined" color="primary">
           <MdCancel />
         </IconButton>

--- a/client/src/components/button/iconButton/IconButton.stories.tsx
+++ b/client/src/components/button/iconButton/IconButton.stories.tsx
@@ -30,7 +30,7 @@ export const Sizes: Story = {
   render: () => (
     <>
       <>
-        <p>Variants: primary, secondary, info, error, transparent, disabled</p>
+        <p>Variants: primary, secondary, info, error, no color, disabled</p>
         <div>
           <h6>Small</h6>
           <IconButton onClick={fn} size="small" color="primary">
@@ -45,7 +45,7 @@ export const Sizes: Story = {
           <IconButton onClick={fn} size="small" color="error">
             <MdCancel />
           </IconButton>
-          <IconButton onClick={fn} size="small" color="transparent">
+          <IconButton onClick={fn} size="small">
             <MdCancel />
           </IconButton>
           <IconButton size="small" disabled>
@@ -66,7 +66,7 @@ export const Sizes: Story = {
           <IconButton onClick={fn} size="medium" color="error">
             <MdCancel />
           </IconButton>
-          <IconButton onClick={fn} size="medium" color="transparent">
+          <IconButton onClick={fn} size="medium">
             <MdCancel />
           </IconButton>
           <IconButton size="medium" disabled>
@@ -87,7 +87,7 @@ export const Sizes: Story = {
           <IconButton size="large" color="error">
             <MdCancel />
           </IconButton>
-          <IconButton size="large" color="transparent">
+          <IconButton size="large">
             <MdCancel />
           </IconButton>
           <IconButton onClick={fn} size="large" disabled>
@@ -116,7 +116,7 @@ export const Variants: Story = {
         <IconButton variant="text" color="error">
           <MdCancel />
         </IconButton>
-        <IconButton variant="text" color="transparent">
+        <IconButton variant="text">
           <MdCancel />
         </IconButton>
         <IconButton variant="text" disabled>
@@ -137,7 +137,7 @@ export const Variants: Story = {
         <IconButton variant="fill" color="error">
           <MdCancel />
         </IconButton>
-        <IconButton variant="fill" color="transparent">
+        <IconButton variant="fill">
           <MdCancel />
         </IconButton>
         <IconButton variant="fill" disabled>
@@ -158,7 +158,7 @@ export const Variants: Story = {
         <IconButton variant="outlined" color="error">
           <MdCancel />
         </IconButton>
-        <IconButton variant="outlined" color="transparent">
+        <IconButton variant="outlined">
           <MdCancel />
         </IconButton>
         <IconButton variant="outlined" disabled>

--- a/client/src/components/button/iconButton/IconButton.tsx
+++ b/client/src/components/button/iconButton/IconButton.tsx
@@ -12,9 +12,14 @@ import Icon from '@/components/icon/Icon';
  * this component automatically wraps it up.
  */
 function IconButton(props: IconButtonProps): React.JSX.Element {
-  const { className = '', children, size = 'medium', ...others } = props;
+  const { className = '', children, size = 'medium', variant = 'fill', ...others } = props;
   return (
-    <Button size={size} className={`component-icon-button ${className}`} {...others}>
+    <Button
+      variant={variant}
+      size={size}
+      className={`component-icon-button ${className}`}
+      {...others}
+    >
       <Icon size={size}>{children}</Icon>
     </Button>
   );

--- a/client/src/components/button/types.ts
+++ b/client/src/components/button/types.ts
@@ -2,7 +2,11 @@ import { BaseButtonWithIconProps } from '../types/BaseButton';
 import { palette, size, variant } from '../types/options';
 
 export interface ButtonProps extends BaseButtonWithIconProps {
-  color?: palette | 'transparent';
+  /**
+   * If no color is passed,
+   * the component will provide default styling with mostly transparent colors
+   */
+  color?: palette;
   size?: size;
   variant?: variant;
 }

--- a/client/src/components/button/types.ts
+++ b/client/src/components/button/types.ts
@@ -1,7 +1,8 @@
 import { BaseButtonWithIconProps } from '../types/BaseButton';
-import { palette, size } from '../types/options';
+import { palette, size, variant } from '../types/options';
 
 export interface ButtonProps extends BaseButtonWithIconProps {
   color?: palette | 'transparent';
   size?: size;
+  variant?: variant;
 }

--- a/client/src/components/types/options.ts
+++ b/client/src/components/types/options.ts
@@ -9,3 +9,8 @@ export type size = 'small' | 'medium' | 'large';
  * Unless stated otherwise, defaults to ``left``.
  */
 export type side = 'left' | 'right' | 'top' | 'bottom';
+
+/**
+ * Determines how palette colors are applied to the element.
+ */
+export type variant = 'fill' | 'text' | 'outlined';

--- a/client/src/styles/README.md
+++ b/client/src/styles/README.md
@@ -14,17 +14,20 @@ The colors and effects also take into account the user's preferences in regards 
 
 ### Colors
 
-When you want to apply a palette color (e.g. primary, secondary) to a component, you can use classes like `.primary`, `.secondary` and similar.
-These classes are a combination of the `.background-[palette]` and `.text-on-[palette]` (which applies an appropriate constrast text color) classes which you can also use if you wish to. `text-[palette]` applies a text color of the given palette.
-
-Normally, each palette class defines a contrast text for its color. However, this occassionally does not apply correctly to some elements (e.g. a native `button` tag). You can bypass it like this:
-
-```css
-/** Substitute ``primary`` with whatever color you want */
-.primary .contrast-text-color
-```
-
 Currently, the palette options are primary, secondary, success, warning, info, and error.
+
+```scss
+@mixin apply-palette-backgrounds();
+@mixin apply-palette-text();
+@mixin apply-palette-outlined-text();
+```
+These mixins apply styling to elements with the following classes, in order:
+- ``background-{palette}``
+- ``text-{palette}``
+- ``outlined-{palette}``
+where ``{palette}`` is each palette color.
+
+The background class will apply the palette color as a background color with an appropriate contrast text. The text class applies the palette as a text color. The outlined class applies the palette as a text and border color (by default, the border has a width of 1px).
 
 The following SCSS variables (representing the app's theming) are available:
 
@@ -55,7 +58,7 @@ It is preferable to use the mixins, as they handle user preferences and stuff li
 ```scss
 @mixin apply-palette-effects();
 ```
-Applies a class for each palette option in the format ``.{palette}-effects`` (e.g. ``.primary-effects``). These classes handle an element's hover, active, focused, and disabled states.
+Applies styling for elements with classes in the format ``.{palette}-effects`` (e.g. ``.primary-effects``). These styles handle an element's hover, active, focused, and disabled states with colors appropriate for the palette.
 
 ```scss
 @mixin apply-accent-hover();

--- a/client/src/styles/README.md
+++ b/client/src/styles/README.md
@@ -18,8 +18,8 @@ Currently, the palette options are primary, secondary, success, warning, info, a
 
 ```scss
 @mixin apply-palette-backgrounds();
-@mixin apply-palette-text();
-@mixin apply-palette-outlined-text();
+@mixin apply-palette-text($interactive: false);
+@mixin apply-palette-outlined-text($interactive: false);
 ```
 These mixins apply styling to elements with the following classes, in order:
 - ``background-{palette}``
@@ -28,6 +28,8 @@ These mixins apply styling to elements with the following classes, in order:
 where ``{palette}`` is each palette color.
 
 The background class will apply the palette color as a background color with an appropriate contrast text. The text class applies the palette as a text color. The outlined class applies the palette as a text and border color (by default, the border has a width of 1px).
+
+For the text and outlined variants, you can also mark them as interactive, which applies a ripple of the respective colors.
 
 The following SCSS variables (representing the app's theming) are available:
 
@@ -67,10 +69,12 @@ Applies styling for elements with classes in the format ``.{palette}-effects`` (
 These mixins provide styling for elements' hover and active states, using the app's accent colors.
 
 ```scss
-@mixin ripple();
+@mixin ripple($ripple-color-light: black, $ripple-color-dark: white)
 ```
 
 Applies a ripple effect that triggers when the element is clicked. Note that the effect starts from the center (regardless of where the user clicks) and that the ripple is activated regardless of the user's animation preferences.
+
+By default, the ripple color is black or white, depending on the current theme. You can configure the colors for both themes via parameters.
 
 ### Font
 

--- a/client/src/styles/colors.scss
+++ b/client/src/styles/colors.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use 'sass:color';
 @import './util.scss';
 
 $primary-colors: (
@@ -85,26 +86,34 @@ $palette: (
   }
 }
 
-@mixin apply-palette-text() {
+@mixin apply-palette-text($interactive: false) {
   @each $color, $values in $palette {
     &.text-#{$color} {
       @include apply-values-for-modes(color, map.get($values, 'dark'), map.get($values, 'light'));
+
+      @if $interactive {
+        @include ripple(map.get($values, 'light'), map.get($values, 'dark'));
+
+        &:hover:not(:disabled) {
+          @include apply-values-for-modes(
+            background-color,
+            color.adjust(map.get($values, 'dark'), $alpha: -0.9),
+            color.adjust(map.get($values, 'light'), $alpha: -0.9)
+          );
+        }
+      }
 
       &:disabled,
       & :disabled,
       &.disabled,
       & .disabled {
-        @include apply-values-for-modes(
-          color,
-          rgba(255, 255, 255, 0.12),
-          rgba(0, 0, 0, 0.12)
-        );
+        @include apply-values-for-modes(color, rgba(255, 255, 255, 0.12), rgba(0, 0, 0, 0.12));
       }
     }
   }
 }
 
-@mixin apply-palette-outlined-text() {
+@mixin apply-palette-outlined-text($interactive: false) {
   @each $color, $values in $palette {
     &.outlined-#{$color} {
       @include apply-values-for-modes(
@@ -112,6 +121,18 @@ $palette: (
         map.get($values, 'dark'),
         map.get($values, 'light')
       );
+
+      @if $interactive {
+        @include ripple(map.get($values, 'light'), map.get($values, 'dark'));
+
+        &:hover:not(:disabled, .disabled) {
+          @include apply-values-for-modes(
+            background-color,
+            color.adjust(map.get($values, 'dark'), $alpha: -0.9),
+            color.adjust(map.get($values, 'light'), $alpha: -0.9)
+          );
+        }
+      }
 
       @include apply-values-for-modes(color, map.get($values, 'dark'), map.get($values, 'light'));
       border-width: 1px;
@@ -121,11 +142,7 @@ $palette: (
       & :disabled,
       &.disabled,
       & .disabled {
-        @include apply-values-for-modes(
-          color,
-          rgba(255, 255, 255, 0.12),
-          rgba(0, 0, 0, 0.12)
-        );
+        @include apply-values-for-modes(color, rgba(255, 255, 255, 0.12), rgba(0, 0, 0, 0.12));
 
         @include apply-values-for-modes(
           border-color,

--- a/client/src/styles/colors.scss
+++ b/client/src/styles/colors.scss
@@ -93,6 +93,17 @@ $palette: (
   }
 }
 
+@mixin apply-palette-outlined-text() {
+  @each $color, $values in $palette {
+    &.outlined-#{$color} {
+      @include apply-values-for-modes(border-color, map.get($values, 'dark'), map.get($values, 'light'));
+      @include apply-values-for-modes(color, map.get($values, 'dark'), map.get($values, 'light'));
+      border-width: 1px;
+      border-style: solid;
+    }
+  }
+}
+
 $background-dark: #121212;
 $background-light: #e9e4e4;
 $accent-light: white;

--- a/client/src/styles/colors.scss
+++ b/client/src/styles/colors.scss
@@ -89,6 +89,17 @@ $palette: (
   @each $color, $values in $palette {
     &.text-#{$color} {
       @include apply-values-for-modes(color, map.get($values, 'dark'), map.get($values, 'light'));
+
+      &:disabled,
+      & :disabled,
+      &.disabled,
+      & .disabled {
+        @include apply-values-for-modes(
+          color,
+          rgba(255, 255, 255, 0.12),
+          rgba(0, 0, 0, 0.12)
+        );
+      }
     }
   }
 }
@@ -96,10 +107,32 @@ $palette: (
 @mixin apply-palette-outlined-text() {
   @each $color, $values in $palette {
     &.outlined-#{$color} {
-      @include apply-values-for-modes(border-color, map.get($values, 'dark'), map.get($values, 'light'));
+      @include apply-values-for-modes(
+        border-color,
+        map.get($values, 'dark'),
+        map.get($values, 'light')
+      );
+
       @include apply-values-for-modes(color, map.get($values, 'dark'), map.get($values, 'light'));
       border-width: 1px;
       border-style: solid;
+
+      &:disabled,
+      & :disabled,
+      &.disabled,
+      & .disabled {
+        @include apply-values-for-modes(
+          color,
+          rgba(255, 255, 255, 0.12),
+          rgba(0, 0, 0, 0.12)
+        );
+
+        @include apply-values-for-modes(
+          border-color,
+          rgba(255, 255, 255, 0.12),
+          rgba(0, 0, 0, 0.12)
+        );
+      }
     }
   }
 }

--- a/client/src/styles/effects.scss
+++ b/client/src/styles/effects.scss
@@ -3,7 +3,7 @@
 
 $outline-color: #50dfff;
 
-@mixin ripple() {
+@mixin ripple($ripple-color-light: black, $ripple-color-dark: white) {
   position: relative;
   overflow: hidden;
   transform: translate3d(0, 0, 0);
@@ -19,8 +19,8 @@ $outline-color: #50dfff;
     pointer-events: none;
     @include apply-values-for-modes(
       background-image,
-      radial-gradient(circle, white 10%, transparent 10.01%),
-      radial-gradient(circle, black 10%, transparent 10.01%)
+      radial-gradient(circle, $ripple-color-dark 10%, transparent 10.01%),
+      radial-gradient(circle, $ripple-color-dark 10%, transparent 10.01%)
     );
     background-repeat: no-repeat;
     background-position: 50%;
@@ -141,7 +141,7 @@ $effects: (
   @include apply-transition(background-color 0.2s);
 }
 
-@mixin ripple() {
+@mixin ripple($ripple-color-light: black, $ripple-color-dark: white) {
   position: relative;
   overflow: hidden;
   transform: translate3d(0, 0, 0);
@@ -157,8 +157,8 @@ $effects: (
     pointer-events: none;
     @include apply-values-for-modes(
       background-image,
-      radial-gradient(circle, white 10%, transparent 10.01%),
-      radial-gradient(circle, black 10%, transparent 10.01%)
+      radial-gradient(circle, $ripple-color-dark 10%, transparent 10.01%),
+      radial-gradient(circle, $ripple-color-light 10%, transparent 10.01%)
     );
     background-repeat: no-repeat;
     background-position: 50%;

--- a/client/src/util/generateVariantClassName/generateVariantClassName.ts
+++ b/client/src/util/generateVariantClassName/generateVariantClassName.ts
@@ -1,0 +1,13 @@
+import { variant } from '@/components/types/options';
+
+type variantClassName = 'background' | 'text' | 'outlined';
+
+const variants: Record<variant, variantClassName> = {
+  fill: 'background',
+  text: 'text',
+  outlined: 'outlined',
+};
+
+export function generateVariantClassName(variant: variant): variantClassName {
+  return variants[variant];
+}


### PR DESCRIPTION
Buttons now come in three variants: fill (default), text, and outlined.

- Fill buttons are what buttons were up until this PR, meaning that the color passed to them acts as a background one
- Text buttons apply the passed color as a text color
- Outlined buttons are text buttons with a corresponding border color

Other things:
- Buttons are no longer "transparent". Instead, they are now "colorless" and can be used by simply not passing a color at all.
- Icon buttons are now inline-flex to fix an issue with alignment of link icon buttons
- Stories have been updated not only with the new variants, but also with a few missing colors.